### PR TITLE
Make it work on Android phones

### DIFF
--- a/services/playback.js
+++ b/services/playback.js
@@ -41,16 +41,15 @@
 			}
 		}
 
-		var audiotag = null;
+		var audiotag = new Audio();
 
 		function createAndPlayAudio(url, callback, endcallback) {
 			console.log('createAndPlayAudio', url);
-			if (audiotag != null) {
+			if (audiotag.src != null) {
 				audiotag.pause();
-				delete(audiotag);
-				audiotag = null;
+				audiotag.src = null;
 			}
-			audiotag = new Audio(url);
+			audiotag.src = url;
 			audiotag.addEventListener('loadedmetadata', function() {
 				console.log('audiotag loadedmetadata');
 				_duration = audiotag.duration * 1000.0;
@@ -83,6 +82,15 @@
 				_playing = true;
 				_progress = 0;
 				var trackid = trackuri.split(':')[2];
+
+				// workaround to be able to play on mobile
+				// we need to play as a response to a touch event
+				// play + immediate pause of an empty song does the trick
+				// see http://stackoverflow.com/questions/12517000/no-sound-on-ios-6-web-audio-api
+				audiotag.src='';
+				audiotag.play();
+				audiotag.pause();
+
 				API.getTrack(trackid).then(function(trackdata) {
 					console.log('playback got track', trackdata);
 					createAndPlayAudio(trackdata.preview_url, function() {


### PR DESCRIPTION
On Android (and most probably the rest of mobile devices) audio can't be play from the `Audio` object unless it's a result of a direct user touch event. Similar to how popup blocking works. As a result, the phone doesn't play anything.

Even though it seems the user tapping a track should lead to playing that track as a direct action, the promise used in `$http` in `API.getTrack()` disconnects the _callback_ from the user touch action.

A workaround is to start playing as the user taps, and change the `src` once we get the URL for the track.
